### PR TITLE
Improve security and robustness of DICOM conversion

### DIFF
--- a/rtCommon/imageHandling.py
+++ b/rtCommon/imageHandling.py
@@ -268,11 +268,9 @@ def convertDicomFileToNifti(dicomFilename, niftiFilename):
     outPath, outName = os.path.split(niftiFilename)
     if outName.endswith('.nii'):
         outName = os.path.splitext(outName)[0]  # remove extention
-    cmd = '{bin} -s y -b n -o {outdir} -f {outname} {inname}'.format(
-        bin=dcm2niiCmd, outdir=outPath, outname=outName, inname=dicomFilename
-        )
-    # os.system(cmd)
-    subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL)
+    cmd = [dcm2niiCmd, '-s', 'y', '-b', 'n', '-o', outPath, '-f', outName,
+           dicomFilename]
+    subprocess.run(cmd, shell=False, stdout=subprocess.DEVNULL)
 
 
 def readNifti(niftiFilename):


### PR DESCRIPTION
The Python `subprocess.run` command, when run with `shell=True`, has two
primary issues here:

1) When `shell=True`, the command to execute is specified by a single,
   constructed string, and the shell executes that string exactly as if
   it were typed by the user.  This means that if the argument string
   includes any paths containing spaces, those paths will not be properly
   quoted, Accordingly, the `dcm2nii` command will fail to properly parse
   the arguments when executed in the shell, and thus fail to convert the
   DICOM image.

2) `shell=True` also introduces a potential shell injection vulnerability;
   since users may provide arbitrary filename strings that are directly
   included in the cmd string, it is best to avoid using `shell=True`.

Specifying the command to execute as a list of strings (instead of a
single string) and specifying `shell=False` fixes both the robustness and
the security issue.

Fixes #11 