### PR TITLE
Add option to write out only data from BIDS Incremental

### DIFF
--- a/rtCommon/bidsIncremental.py
+++ b/rtCommon/bidsIncremental.py
@@ -574,7 +574,7 @@ class BidsIncremental:
         """
         return bids_build_path(self._imgMetadata, BIDS_DIR_PATH_PATTERN)
 
-    def writeToDisk(self, datasetRoot: str) -> None:
+    def writeToDisk(self, datasetRoot: str, onlyData=False) -> None:
         """
         Writes the incremental's data to a directory on disk. NOTE: The
         directory is assumed to be empty, and no checks are made for data that
@@ -582,6 +582,10 @@ class BidsIncremental:
 
         Args:
             datasetRoot: Path to the root of the BIDS archive to be written to.
+            onlyData: Only write out the NIfTI image and sidecar metadata
+                (Default False). Useful if writing an incremental out to an
+                existing archive and you don't want to overwrite existing README
+                or dataset_description.json files.
 
         Examples:
             >>> from bidsArchive import BidsArchive
@@ -615,12 +619,13 @@ class BidsIncremental:
         with open(eventsPath, mode='w') as eventsFile:
             self.events.to_csv(eventsFile, sep='\t')
 
-        # Write out dataset description
-        with open(descriptionPath, mode='w') as description:
-            json.dump(self.datasetMetadata, description, indent=4)
+        if not onlyData:
+            # Write out dataset description
+            with open(descriptionPath, mode='w') as description:
+                json.dump(self.datasetMetadata, description, indent=4)
 
-        # Write out readme
-        with open(readmePath, mode='w') as readme:
-            readme.write(self.readme)
+            # Write out readme
+            with open(readmePath, mode='w') as readme:
+                readme.write(self.readme)
 
     """ END BIDS-I ARCHIVE EMULTATION API """

--- a/tests/test_bidsIncremental.py
+++ b/tests/test_bidsIncremental.py
@@ -393,6 +393,13 @@ def testDiskOutput(validBidsI, tmpdir):
 
     assert isValidBidsArchive(archive.rootPath)
 
+    # Try only writing data
+    datasetRoot = os.path.join(tmpdir, "bids-pytest-dataset-2")
+    validBidsI.writeToDisk(datasetRoot, onlyData=True)
+    assert not os.path.exists(os.path.join(datasetRoot, "README"))
+    assert not os.path.exists(os.path.join(datasetRoot,
+                                           "dataset_description.json"))
+
 
 # Test serialization results in equivalent BIDS-I object
 def testSerialization(validBidsI, sample4DNifti1, imageMetadata, tmpdir):


### PR DESCRIPTION
When writing out a BIDS Incremental to an existing archive, the README
and dataset_description.json files will be overwritten by the values in
the incremental. This change enables writing just the image data and
metadata contained in the incremental, without any of the dataset-wide
files.