### PR TITLE
Implement BidsRun

### DIFF
--- a/rtCommon/bidsRun.py
+++ b/rtCommon/bidsRun.py
@@ -1,0 +1,197 @@
+"""-----------------------------------------------------------------------------
+
+bidsRun.py
+
+Implements the BIDS Run data type used for representing full fMRI scanning runs
+as sequences of BIDS incrementals.
+
+-----------------------------------------------------------------------------"""
+import logging
+
+import numpy as np
+
+from rtCommon.bidsCommon import (
+    getNiftiData,
+    metadataAppendCompatible,
+    niftiImagesAppendCompatible,
+    symmetricDictDifference,
+)
+from rtCommon.bidsIncremental import BidsIncremental
+from rtCommon.errors import MetadataMismatchError
+
+logger = logging.getLogger(__name__)
+
+
+class BidsRun:
+    def __init__(self, **entities):
+        self.incrementals = []
+        self._entities = entities
+
+    def __eq__(self, other):
+        if self.numIncrementals() == other.numIncrementals():
+            if self.getRunEntities() == other.getRunEntities():
+                if self.incrementals == other.incrementals:
+                    return True
+        return False
+
+    def getIncremental(self, index: int) -> BidsIncremental:
+        """
+        Returns the incremental in the run at the provided index.
+
+        Arguments:
+            index: Which image of the run to get (0-indexed)
+
+        Returns:
+            Incremental at provided index.
+
+        Raises:
+            IndexError: If index is out of bounds for this run.
+
+        Examples:
+            >>> print(run.numIncrementals())
+            5
+            >>> inc = run.getIncremental(1)
+            >>> inc2 = run.getIncremental(5)
+            IndexError
+        """
+        try:
+            return self.incrementals[index]
+        except IndexError:
+            raise IndexError(f"Index {index} out of bounds for run with "
+                             f"{self.numIncrementals()} incrementals")
+
+    def appendIncremental(self, incremental: BidsIncremental,
+                          validateAppend: bool = True) -> None:
+        """
+        Appends an incremental to this run's data, setting the run's entities if
+        the run is empty.
+
+        Arguments:
+            incremental: The incremental to add to the run.
+            validateAppend: Validate the incremental matches the current run's
+                data (default True). Turning off is useful for efficiently
+                creating a whole run at once from an existing image volume,
+                where all data is known to be match already.
+
+        Raises:
+            MetadataMismatchError: If either the incremental's entities, its
+                images's NIfTI header, or its metadata doesn't match the
+                existing run's data.
+
+        Examples:
+            Suppose a NIfTI image and metadata dictionary are available in the
+            environment.
+
+            >>> incremental = BidsIncremental(image, metadata)
+            >>> run = BidsRun()
+            >>> run.appendIncremental(incremental)
+            >>> metadata['subject'] = 'new_subject'
+            >>> incremental2 = BidsIncremental(image, metadata)
+            >>> run.appendIncremental(incremental2)
+            MetadataMismatchError
+        """
+        # Set this run's entities if not already present
+        if len(self._entities) == 0:
+            self._entities = incremental.entities
+
+        if validateAppend:
+            if not incremental.entities == self._entities:
+                entityDifference = symmetricDictDifference(self._entities,
+                                                           incremental.entities)
+                errorMsg = ("Incremental's BIDS entities do not match this "
+                            f"run's entities (difference: {entityDifference})")
+                raise MetadataMismatchError(errorMsg)
+
+            if self.numIncrementals() > 0:
+                canAppend, niftiErrorMsg = \
+                    niftiImagesAppendCompatible(incremental.image,
+                                                self.incrementals[-1].image)
+
+                if not canAppend:
+                    errorMsg = ("Incremental's NIfTI header not compatible "
+                                f" with this run's images ({niftiErrorMsg})")
+                    raise MetadataMismatchError(errorMsg)
+
+                canAppend, metadataErrorMsg = metadataAppendCompatible(
+                    incremental.imageMetadata,
+                    self.incrementals[-1].imageMetadata)
+
+                if not canAppend:
+                    errorMsg = ("Incremental's metadata not compatible "
+                                f" with this run's images ({metadataErrorMsg})")
+                    raise MetadataMismatchError(errorMsg)
+
+        # Slice up the incremental into smaller incrementals if it has multiple
+        # images in its image volume
+        imagesInVolume = incremental.imageDimensions[3]
+        if imagesInVolume == 1:
+            self.incrementals.append(incremental)
+        else:
+            # Split up the incremental into single-image volumes
+            image = incremental.image
+            imageData = getNiftiData(image)
+            affine = image.affine
+            header = image.header
+            metadata = incremental.imageMetadata
+
+            for imageIdx in range(imagesInVolume):
+                newData = imageData[..., imageIdx]
+                newImage = incremental.image.__class__(newData, affine, header)
+                newIncremental = BidsIncremental(newImage, metadata)
+                self.incrementals.append(newIncremental)
+
+    def asSingleIncremental(self) -> BidsIncremental:
+        """
+        Coalesces the entire run into a single BIDS-I that can be sent over a
+        network, written to disk, or added to an archive.
+
+        Returns:
+            BidsIncremental with all image data and metadata represented by the
+                incrementals composing the run.
+
+        Examples:
+            >>> incremental = run.asSingleIncremental()
+            >>> incremental.writeToDisk('/tmp/new_dataset')
+        """
+        numIncrementals = self.numIncrementals()
+        refIncremental = self.getIncremental(0)
+        newImageShape = refIncremental.imageDimensions[:3] + (numIncrementals,)
+        metadata = refIncremental.imageMetadata
+
+        # It is critical to set the dtype of the array according to the source
+        # image's dtype. Without doing so, int data may be cast to float (the
+        # numpy default type for a new array), which Nibabel will then write
+        # float data to disk using the NIfTI scl_scope header scaling field.
+        # This procedure almost always results in less precision than offered by
+        # the original ints, which means images at either end of a round-trip
+        # (read image data/put image data in numpy array/save image data/read
+        # image from disk) will have arrays with slightly different values.
+        newDataArray = np.zeros(newImageShape, order='F',
+                                dtype=refIncremental.image.dataobj.dtype)
+
+        for incIdx in range(numIncrementals):
+            incremental = self.getIncremental(incIdx)
+            newDataArray[..., incIdx] = getNiftiData(incremental.image)[..., 0]
+
+        newImage = refIncremental.image.__class__(newDataArray,
+                                                  refIncremental.image.affine,
+                                                  refIncremental.image.header)
+
+        return BidsIncremental(newImage, metadata)
+
+    def numIncrementals(self) -> int:
+        """
+        Returns number of incrementals in this run.
+        """
+        return len(self.incrementals)
+
+    def getRunEntities(self) -> dict:
+        """
+        Returns dictionary of the BIDS entities associated with this run.
+
+        Examples:
+            >>> print(run.getRunEntities())
+            {'subject': '01', 'session': '01', 'task': 'test', run: 1,
+            'datatype': 'func', 'suffix': 'bold'}
+        """
+        return self._entities

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,16 +145,21 @@ def sample4DNifti1():
 def sampleNifti2():
     return readNifti(test_4DNifti2Path)
 
+# Set of BIDS entities needed for BIDS-I creation
+@pytest.fixture(scope='function')
+def sampleBidsEntities():
+    return {'subject': '01', 'task': 'faces', 'suffix': 'bold', 'datatype':
+            'func', 'session': '01', 'run': 1}
+
 
 @pytest.fixture(scope='function')
-def imageMetadata(dicomImageMetadata):
+def imageMetadata(dicomImageMetadata, sampleBidsEntities):
     """
     Dictionary with all required metadata to construct a BIDS-Incremental, as
     well as extra metadata extracted from the test DICOM image.
     """
-    meta = {'subject': '01', 'task': 'faces', 'suffix': 'bold', 'datatype':
-            'func', 'session': '01', 'run': 1}
-    meta.update(dicomImageMetadata)  # DICOM
+    meta = sampleBidsEntities.copy()
+    meta.update(dicomImageMetadata)
     return meta
 
 
@@ -166,6 +171,17 @@ def validBidsI(sample4DNifti1, imageMetadata):
     return BidsIncremental(image=sample4DNifti1,
                            imageMetadata=imageMetadata)
 
+@pytest.fixture(scope='function')
+def oneImageBidsI(sample4DNifti1, imageMetadata):
+    """
+    Constructs and returns a known-valid BIDS-Incremental using known metadata.
+    """
+    newData = getNiftiData(sample4DNifti1)[..., 0]
+    newImage = sample4DNifti1.__class__(newData, sample4DNifti1.affine,
+                                        sample4DNifti1.header)
+
+    return BidsIncremental(image=newImage,
+                           imageMetadata=imageMetadata)
 
 def archiveWithImage(image, metadata: dict, tmpdir):
     """

--- a/tests/test_bidsRun.py
+++ b/tests/test_bidsRun.py
@@ -1,0 +1,167 @@
+import logging
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+from rtCommon.bidsCommon import getNiftiData
+from rtCommon.bidsIncremental import BidsIncremental
+from rtCommon.bidsRun import BidsRun
+from rtCommon.errors import MetadataMismatchError
+
+logger = logging.getLogger(__name__)
+
+
+# Test equality check is correct
+def testEq(oneImageBidsI):
+    run1 = BidsRun()
+    run2 = BidsRun()
+
+    run1.appendIncremental(oneImageBidsI)
+    assert run1 != run2
+
+    run2.appendIncremental(oneImageBidsI)
+    assert run1 == run2
+
+    run2._entities['subject'] = "new_subect"
+    assert run1 != run2
+
+
+# Test numIncrementals output is correct
+def testNumIncrementals(oneImageBidsI):
+    run = BidsRun()
+    assert run.numIncrementals() == 0
+
+    NUM_APPENDS = 20
+    for i in range(NUM_APPENDS):
+        run.appendIncremental(oneImageBidsI)
+        assert run.numIncrementals() == i + 1
+
+
+# Test out of bounds values for get incremental
+def testGetOutOfBounds(oneImageBidsI):
+    run = BidsRun()
+
+    NUM_APPENDS = 10
+    for i in range(NUM_APPENDS):
+        run.appendIncremental(oneImageBidsI)
+
+    # This is inbounds due to how negative indexing works
+    assert run.getIncremental(0) == run.getIncremental(-1 * NUM_APPENDS)
+
+    with pytest.raises(IndexError):
+        run.getIncremental(NUM_APPENDS)
+    with pytest.raises(IndexError):
+        run.getIncremental(NUM_APPENDS + 1)
+    with pytest.raises(IndexError):
+        run.getIncremental(-1 * NUM_APPENDS - 1)
+
+
+# Test get and append
+def testGetAppendIncremental(oneImageBidsI):
+    run = BidsRun()
+
+    run.appendIncremental(oneImageBidsI)
+    assert run.getIncremental(0) == oneImageBidsI
+
+    NUM_APPENDS = 20
+    for i in range(1, NUM_APPENDS):
+        oneImageBidsI.setMetadataField('append_num', i)
+        run.appendIncremental(oneImageBidsI)
+        assert run.getIncremental(i).getMetadataField('append_num') == i
+        assert run.getIncremental(-1).getMetadataField('append_num') == i
+        assert run.numIncrementals() == i + 1
+
+
+# Test construction
+def testConstruction(oneImageBidsI, sampleBidsEntities):
+    runWithoutEntities = BidsRun()
+    assert runWithoutEntities is not None
+    assert len(runWithoutEntities.getRunEntities()) == 0
+
+    runWithEntities = BidsRun(**sampleBidsEntities)
+    assert runWithEntities is not None
+    assert runWithEntities.getRunEntities() == sampleBidsEntities
+
+
+# Test append correctly sets entities
+def testAppendSetEntities(oneImageBidsI, sampleBidsEntities):
+    run = BidsRun()
+    run.appendIncremental(oneImageBidsI)
+    assert run.getRunEntities() == sampleBidsEntities
+
+
+# Test append works correctly if entities are set but incremental list is empty
+def testAppendEmptyIncrementals(oneImageBidsI, sampleBidsEntities):
+    run = BidsRun(**sampleBidsEntities)
+    run.appendIncremental(oneImageBidsI)
+    assert run.numIncrementals() == 1
+
+
+# Test append doesn't work with mismatched entities
+def testAppendConflictingEntities(oneImageBidsI):
+    differentBidsInc = BidsIncremental(oneImageBidsI.image,
+                                       oneImageBidsI.imageMetadata)
+    differentBidsInc.setMetadataField("subject", "new-subject")
+
+    run = BidsRun()
+    run.appendIncremental(oneImageBidsI)
+    with pytest.raises(MetadataMismatchError):
+        run.appendIncremental(differentBidsInc)
+
+
+# Test append doesn't work if NIfTI headers don't match
+def testAppendConflictingNiftiHeaders(oneImageBidsI, imageMetadata):
+    # Change the pixel dimensions (zooms) to make the image append-incompatible
+    image2 = nib.Nifti1Image(oneImageBidsI.image.dataobj,
+                             oneImageBidsI.image.affine,
+                             oneImageBidsI.image.header)
+    new_data_shape = tuple(i * 2 for i in image2.header.get_zooms())
+    image2.header.set_zooms(new_data_shape)
+    bidsInc2 = BidsIncremental(image2, imageMetadata)
+
+    run = BidsRun()
+    run.appendIncremental(oneImageBidsI)
+    with pytest.raises(MetadataMismatchError):
+        run.appendIncremental(bidsInc2)
+
+    # Append should work now with validateAppend turned off
+    numIncrementalsBefore = run.numIncrementals()
+    run.appendIncremental(bidsInc2, validateAppend=False)
+    assert run.numIncrementals() == (numIncrementalsBefore + 1)
+
+
+# Test append doesn't work if metadata doesn't match
+def testAppendConflictingMetadata(oneImageBidsI):
+    bidsInc2 = BidsIncremental(oneImageBidsI.image, oneImageBidsI.imageMetadata)
+    bidsInc2.setMetadataField('subject', 'definitely_invalid_name')
+
+    run = BidsRun()
+    run.appendIncremental(oneImageBidsI)
+    with pytest.raises(MetadataMismatchError):
+        run.appendIncremental(bidsInc2)
+
+    # Append should work now with validateAppend turned off
+    numIncrementalsBefore = run.numIncrementals()
+    run.appendIncremental(bidsInc2, validateAppend=False)
+    assert run.numIncrementals() == (numIncrementalsBefore + 1)
+
+
+# Test consolidation into single incremental works as expected
+def testAsSingleIncremental(oneImageBidsI):
+    run = BidsRun()
+    NUM_APPENDS = 5
+    for i in range(NUM_APPENDS):
+        run.appendIncremental(oneImageBidsI)
+
+    oldImage = oneImageBidsI.image
+    imageData = getNiftiData(oldImage)
+    newDataShape = imageData.shape[:3] + (NUM_APPENDS,)
+    newData = np.zeros(newDataShape, dtype=imageData.dtype)
+    for i in range(NUM_APPENDS):
+        newData[..., i] = imageData[..., 0]
+
+    newImage = oldImage.__class__(newData, oldImage.affine, oldImage.header)
+    consolidatedBidsI = BidsIncremental(newImage, oneImageBidsI.imageMetadata)
+
+    assert run.asSingleIncremental() == consolidatedBidsI


### PR DESCRIPTION
BidsRun represents an entire fMRI scanning run, storing all incrementals
that make up the run in memory. Key features are:

* Addition of incrementals to the run

* Retrieval of incrementals previously stored in the run

* Automatic checks that newly added incrementals match the rest of the run

* Functionality to coalsece the run into a single BIDS Incremental,
  which can be useful for network transfer or addition to an archive