### PR TITLE
Integrate BidsRun with BidsArchive

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,7 +265,7 @@ def bidsArchiveMultipleRuns(tmpdir, sample4DNifti1, imageMetadata):
     metadata['run'] = int(metadata['run']) + 1
 
     incremental = BidsIncremental(sample4DNifti1, metadata)
-    archive.appendIncremental(incremental)
+    archive.appendIncremental(incremental, useCache=False)
 
     return archive
 


### PR DESCRIPTION
This PR integrates BidsRun with BidsArchive for improved performance.
Key features are as follows:

* Efficently add a full BIDS Run worth of BIDS Incrementals to an
  archive using appendBidsRun

* Efficiently get a full BIDS Run worth of BIDS Incrementals from an
  archive using getBidsRun

* Automatic caching for BIDS Archive's getIncremental (enabled by
  default) and appendIncremental (disabled by default) for increased
  performance