### PR TITLE
Add entity updating to BidsRun

### DIFF
--- a/rtCommon/bidsCommon.py
+++ b/rtCommon/bidsCommon.py
@@ -282,6 +282,15 @@ def symmetricDictDifference(d1: dict, d2: dict,
         A dictionary with all key-value pair differences between the two
         dictionaries. 'None' is used as the value for a key-value pair if that
         dictionary lacks a key that the other one has.
+
+    Examples:
+        >>> d1 = {'a': 1, 'b': 2, 'c': 3}
+        >>> d2 = {'c': 4, 'd': 5}
+        >>> print(symmetricDictDifference(d1, d2))
+        {'a': [1, None], 'b': [2, None], 'c': [3, 4], 'd': [None, 5]}
+        >>> d2 = {'a': 1, 'b': 2, 'c': 4}
+        >>> print(symmetricDictDifference(d1, d2))
+        {'c': [3, 4]}
     """
 
     sharedKeys = d1.keys() & d2.keys()

--- a/tests/test_bidsRun.py
+++ b/tests/test_bidsRun.py
@@ -164,3 +164,26 @@ def testAsSingleIncremental(oneImageBidsI):
     consolidatedBidsI = BidsIncremental(newImage, oneImageBidsI.imageMetadata)
 
     assert run.asSingleIncremental() == consolidatedBidsI
+
+# Test that updating entities works as expected
+def testUpdateEntities(validBidsI):
+    # Ensure an append updates the run's entities to the full set
+    entities = {key: validBidsI.entities[key] for key in ['subject', 'task']}
+    run = BidsRun(**entities)
+
+    assert run._entities != validBidsI.entities
+    run.appendIncremental(validBidsI)
+    assert run._entities == validBidsI.entities
+
+    # Ensure minimally supplied entities are still sufficient to block a
+    # non-matching run and doesn't update the run's entities
+    entities = {key: validBidsI.entities[key] for key in ['subject', 'task']}
+    run = BidsRun(**entities)
+
+    preAppendEntities = run._entities
+    assert preAppendEntities != validBidsI.entities
+    validBidsI.setMetadataField('subject', 'nonValidSubject')
+    with pytest.raises(MetadataMismatchError):
+        run.appendIncremental(validBidsI)
+    assert run._entities == preAppendEntities
+


### PR DESCRIPTION
This commit implements the following behavior: When users create a
BidsRun, they should be able to specify a set of entities that determine
which BidsIncrementals can be appended to the run. When the
BidsIncrementals are actually appended, if the BidsIncremental matches
the run's entities but also carries additional ones (e.g., a run number
or datatype for a BidsRun that only has 'subject' and 'task' defined),
the BidsRun should update to include these new, non-conflicting
entities.