### PR TITLE
Optimize get single incremental case

### DIFF
--- a/rtCommon/bidsArchive.py
+++ b/rtCommon/bidsArchive.py
@@ -636,7 +636,10 @@ class BidsArchive:
             numImages = image.dataobj.shape[3]
 
             if imageIndex < numImages:
-                image = image.__class__(getNiftiData(image)[..., imageIndex],
+                # Because only a single image is read, it's faster to slice the
+                # Nibabel ArrayProxy (the image's dataobj) so just the relevant
+                # part of disk is accessed
+                image = image.__class__(image.dataobj[..., imageIndex],
                                         affine=image.affine,
                                         header=image.header)
                 image.update_header()


### PR DESCRIPTION
When getting a single incremental, using the Nibabel ArrayProxy is more
efficient than using the Numpy array directly. This is because the
ArrayProxy only reads the relevant part on disk, whereas getting the
full Numpy array reads a substantial amount of un-needed data. While
the latter is more efficient for BidsRun, as the disk access time is
amortized across more data, here it's more efficient just to use the
ArrayProxy.