### PR TITLE
Switch to directly slicing dataobj to avoid unnecessary copy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - brainiak
   - dcm2niix
   - flake8
+  - indexed_gzip  # for efficient random access of gzipped files with Nibabel
   - inflect
   - ipython
   - jupyter

--- a/rtCommon/bidsArchive.py
+++ b/rtCommon/bidsArchive.py
@@ -702,9 +702,12 @@ class BidsArchive:
             metadata = self.getSidecarMetadata(bidsImage)
             metadata.pop('extension')  # only used in PyBids
 
+            # This incremental will typically have a 4th (time) dimension > 1
             incremental = BidsIncremental(niftiImage, metadata)
 
             run = BidsRun()
+            # appendIncremental will take care of splitting the BidsIncremental
+            # into its component 3-D images
             run.appendIncremental(incremental, validateAppend=False)
             return run
 

--- a/rtCommon/bidsRun.py
+++ b/rtCommon/bidsRun.py
@@ -11,7 +11,6 @@ import logging
 import numpy as np
 
 from rtCommon.bidsCommon import (
-    getNiftiData,
     metadataAppendCompatible,
     niftiHeadersAppendCompatible,
     symmetricDictDifference,
@@ -166,9 +165,9 @@ class BidsRun:
         # Slice up the incremental into smaller component images if it has
         # multiple images in its image volume
         imagesInVolume = incremental.imageDimensions[3]
-        imageData = getNiftiData(incremental.image)
 
-        newArrays = [imageData[..., imageIdx] for imageIdx in
+        # Slice the dataobj so we ensure that data is read into memory
+        newArrays = [incremental.image.dataobj[..., imageIdx] for imageIdx in
                      range(imagesInVolume)]
         if len(self._dataArrays) == 0:
             self._dataArrays = newArrays


### PR DESCRIPTION
Using getNiftiData, which utilized np.asanyarray to get the dataobj as a numpy
array resulted in unexpected behavior:
1) When the dataobj was a np.memmap, it would be passed through, and slicing
the array would result in no data being read in to memory
2) When the dataobj was not a memmap, a copy would be performed, even if the
data had already been read in to memory.

This change uses a lazy load on the getBidsRun side and does the actual memory
reading using direct slicing of the dataobj, ensuring all memory is only read
once.

Closes #44.