### PR TITLE
Add Sphinx for ReadTheDocs automatic doc generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,25 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/module_docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/module_docs/requirements.txt
+  system_packages: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/module_docs/conf.py
+++ b/docs/module_docs/conf.py
@@ -1,0 +1,65 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../'))
+
+# -- Project information -----------------------------------------------------
+
+project = 'rtCloud'
+copyright = '2021, Princeton Neuroscience Institute'
+author = 'Princeton Neuroscience Institute'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'autoapi.extension'
+]
+
+# Set the directories for AutoAPI to find source code
+# AutoAPI's has two advantages over sphinx-apidoc:
+# 1) AutoAPI runs automatically whenever sphinx-build runs, so there's no
+# separate, manual step to generate RST files.
+# 2) AutoAPI uses code parsing instead of code imports, which means there's no
+# need to install the full RT-Cloud conda environment (takes >10m on RTD).
+autoapi_dirs = ['../../rtCommon']
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+# To document __init__
+# https://stackoverflow.com/questions/5599254/how-to-use-sphinxs-autodoc-to-document-a-classs-init-self-method
+autoclass_content = 'both'
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'default'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/module_docs/index.rst
+++ b/docs/module_docs/index.rst
@@ -1,0 +1,19 @@
+.. rtCloud documentation master file, created by
+   sphinx-quickstart on Thu Dec  3 19:48:24 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to rtCloud's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 4
+   :caption: Contents:
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/module_docs/readme.md
+++ b/docs/module_docs/readme.md
@@ -1,0 +1,16 @@
+This README explains how the automated code documentation building system works.
+
+## Initial Setup
+The `sphinx-quickstart` command (more info
+[here](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/sphinx-quickstart.html#quickstart))
+sets up the boilerplate files to fill out.
+
+The `conf.py` file is the primary way of controlling/modifying the building
+process.
+
+## Rebuilding
+`sphinx-build` with type/source/destination arguments builds the docs. The
+AutoAPI extension is configured with the source directory (rtCommon), and it
+automatically discovers modules to document during the `sphinx-build` process.
+
+Example: `sphinx-build -b html module_docs build`

--- a/docs/module_docs/requirements.txt
+++ b/docs/module_docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-autoapi

--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,6 @@ dependencies:
   - websocket-client
   - wsaccel
   - pip:
+    - inotify
     - pybids
     - watchdog
-    - inotify


### PR DESCRIPTION
This PR adds the Sphinx and ReadTheDocs configuration files necessary for linking RT-Cloud to ReadTheDocs for automatic code documentation generation.

Closes #45 