### PR TITLE
Implement automatic NIfTI decompression

### DIFF
--- a/rtCommon/bidsCommon.py
+++ b/rtCommon/bidsCommon.py
@@ -9,8 +9,11 @@ from enum import Enum
 from operator import eq as opeq
 from typing import Any, Callable, Tuple
 import functools
+import gzip
 import logging
+import os
 import re
+import shutil
 
 from bids.layout.models import Config as BidsConfig
 import nibabel as nib
@@ -528,3 +531,21 @@ def metadataAppendCompatible(meta1: dict, meta2: dict) -> Tuple[bool, str]:
             return (False, errorMsg)
 
     return (True, "")
+
+
+def gunzipFile(source: str, destination: str, deleteOriginal: bool = False):
+    """
+    Decompress a gzipped file on disk, optionally deleting the original.
+
+    Args:
+        source: Path to the gzipped file
+        destination: Path to gunzipped output location
+        deleteOriginal: Whether to delete the original, gzipped file after
+            decompressing or not. Default False.
+    """
+    with open(destination, 'wb') as f_out:
+        with gzip.open(source, 'rb') as f_in:
+            shutil.copyfileobj(f_in, f_out)
+
+    if deleteOriginal:
+        os.remove(source)

--- a/tests/test_bidsCommon.py
+++ b/tests/test_bidsCommon.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import numpy as np
 import pytest
@@ -7,6 +8,7 @@ from rtCommon.bidsCommon import (
     adjustTimeUnits,
     getDicomMetadata,
     getNiftiData,
+    gunzipFile,
     loadBidsEntities,
     metadataFromProtocolName,
 )
@@ -126,3 +128,28 @@ def testGetNiftiData(sample4DNifti1):
                                    dtype=sample4DNifti1.dataobj.dtype)
 
     assert np.array_equal(extracted, fromRawDataobj)
+
+
+# Test correct unzipping of a file
+def testGunzipFile(gzippedFile):
+    # Test bad source path
+    with pytest.raises(FileNotFoundError):
+        gunzipFile(source='/we/really/hope/this/file/doesnt/exist',
+                   destination='/tmp/file.out')
+
+    # Test bad destination path
+    with pytest.raises(FileNotFoundError):
+        gunzipFile(source='/tmp/file.out',
+                   destination='/we/really/hope/this/file/doesnt/exist')
+
+    destination, _ = os.path.splitext(gzippedFile)
+
+    # Test don't delete original
+    gunzipFile(gzippedFile, destination, deleteOriginal=False)
+    assert os.path.exists(gzippedFile)
+    assert os.path.exists(destination)
+
+    # Test delete original
+    gunzipFile(gzippedFile, destination, deleteOriginal=True)
+    assert not os.path.exists(gzippedFile)
+    assert os.path.exists(destination)

--- a/tests/test_dataInterface.py
+++ b/tests/test_dataInterface.py
@@ -19,20 +19,6 @@ sampleProjectDicomDir = os.path.join(rtCloudPath, 'projects', 'sample',
 allowedDirs = [tmpDir, testPath, sampleProjectDicomDir, '/tmp']
 allowedFileTypes = ['.bin', 'txt', '.dcm']
 
-@pytest.fixture(scope="module")
-def dicomTestFilename():  # type: ignore
-    return test_dicomPath
-
-@pytest.fixture(scope="module")
-def bigTestFile():  # type: ignore
-    filename = os.path.join(testPath, 'test_input', 'bigfile.bin')
-    if not os.path.exists(filename):
-        with open(filename, 'wb') as fout:
-            for _ in range(101):
-                fout.write(os.urandom(1024*1024))
-    return filename
-
-
 class TestDataInterface:
     serversForTests = None
 


### PR DESCRIPTION
When loading compressed NIfTI image data with Nibabel slice by slice
(such as when getting a BIDS Run), the full image is decompressed each
time a slice is processed. Thus, decompressing NIfTI images ahead of time
substantially increases performance by removing this per-slice overhead.

Closes #44.