### PR TITLE
Fix events file generation

### DIFF
--- a/rtCommon/bidsIncremental.py
+++ b/rtCommon/bidsIncremental.py
@@ -313,7 +313,7 @@ class BidsIncremental:
         numberFields = ["RepetitionTime", "EchoTime"]
         for field in numberFields:
             value = imageMetadata.get(field)
-            if value: 
+            if value:
                 imageMetadata[field] = float(value)
 
         return imageMetadata
@@ -616,7 +616,7 @@ class BidsIncremental:
             json.dump(metadataToWrite, metadataFile, sort_keys=True, indent=4)
 
         with open(eventsPath, mode='w') as eventsFile:
-            self.events.to_csv(eventsFile, sep='\t')
+            self.events.to_csv(eventsFile, index=False, sep='\t')
 
         if not onlyData:
             # Write out dataset description

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,7 +223,8 @@ def archiveWithImage(image, metadata: dict, tmpdir):
     eventsPath = Path(dataPath, bids_build_path(metadata, BIDS_FILE_PATTERN))
     with open(eventsPath, mode='w') as eventsFile:
         eventDefaultHeaders = ['onset', 'duration', 'response_time']
-        pd.DataFrame(columns=eventDefaultHeaders).to_csv(eventsFile, sep='\t')
+        pd.DataFrame(columns=eventDefaultHeaders).to_csv(eventsFile,
+                                                         index=False, sep='\t')
 
     # Create an archive from the directory and return it
     return BidsArchive(rootPath)


### PR DESCRIPTION
Pandas was outputting the empty index column, creating an extra tab at
the beginning of the first line. This caused TSV reading issues on
certain platforms (Ubuntu) that didn't show up on others (macOS).