### PR TITLE
Implement getting dataset files to runs

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -68,7 +68,11 @@ def isValidBidsArchive(archivePath: str, logFullOutput: bool = False) -> bool:
 
         for issue in issueDict:
             issueFiles = issue['files']
-            offendingFileNames = [f['file']['name'] for f in issueFiles]
+            # For the short README error, the file list is empty; other errors
+            # may also have an empty file list, so check to make sure the file
+            # is non-None before trying to get its name
+            offendingFileNames = [f['file']['name'] for f in issueFiles if
+                                  f['file'] is not None]
             issueKey = '{key} (Reason: {reason})'.format(key=issue['key'],
                                                          reason=issue['reason'])
             issueKeysToFiles[issueKey] = offendingFileNames

--- a/tests/test_bidsIncremental.py
+++ b/tests/test_bidsIncremental.py
@@ -244,14 +244,14 @@ def testDatasetMetadata(sample4DNifti1, imageMetadata):
     with pytest.raises(MissingMetadataError):
         BidsIncremental(image=sample4DNifti1,
                         imageMetadata=imageMetadata,
-                        datasetMetadata={"random_field": "doesnt work"})
+                        datasetDescription={"random_field": "doesnt work"})
 
     # Test valid dataset metadata
     dataset_name = "Test dataset"
     bidsInc = BidsIncremental(image=sample4DNifti1,
                               imageMetadata=imageMetadata,
-                              datasetMetadata={"Name": dataset_name,
-                                               "BIDSVersion": "1.0"})
+                              datasetDescription={"Name": dataset_name,
+                                                  "BIDSVersion": "1.0"})
     assert bidsInc.getDatasetName() == dataset_name
 
 


### PR DESCRIPTION
Previously, a BIDS Run did not get the appropriate events file, readme,
and dataset description for the target image and left it to the user to
set them. This change makes retrieving that data from the archive
automatic.