### PR TITLE
Split environment.yml file into two parts, the second for brainiak installation

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -28,7 +28,8 @@ jobs:
         path: /usr/share/miniconda
         key:
           ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('environment.yml') }}
+            hashFiles('environment.yml') }}-${{
+            hashFiles('environment-synthetic-data.yml') }}
 
     - name: Add conda to system path
       run: |
@@ -44,6 +45,7 @@ jobs:
       run: |
         conda list
         conda env update --file environment.yml --name base
+        conda env update --file environment-synthetic-data.yml --name base
 
     - name: Lint with flake8
       run: |

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,8 @@
 # Realtime fMRI Cloud Framework
+
+- [Github Repo](https://github.com/brainiak/rt-cloud)
+- [Read-The-Docs](https://rt-cloud.readthedocs.io)
+
 The Realtime fMRI Cloud Framework is an open-source software package that makes it easier to build and deploy real-time fMRI experiments. The framework provides a coordination hub between the experimenter’s script, a subject feedback script, the scanner data, and experiment control. It streams scanner data (in real-time) to an experimenter’s script and forwards the results for use in subject feedback (optionally using tools like PsychoPy, jsPsych, or PsychToolbox). It provides a web-based user interface that allows for starting and stopping runs, changing settings, and viewing output. It can be configured to run in the cloud, on a cluster, or in the control room. Development was initially funded by Intel Labs; the framework is under active development with funding from NIMH to further extend its capabilities, including support for standards such as BIDS and OpenNeuro.org.
 
 ## How it works
@@ -71,7 +75,7 @@ A subjectService is started on the presentation computer. The subjecService list
     - <code>mkdir certs; openssl genrsa -out certs/rtcloud_private.key 2048</code>
     - <code>bash scripts/make-sslcert.sh -ip *[local_ip_addr]*</code>
 5. Create the conda environment<br>
-    - <code>conda env create -f environment.yml</code>
+    - <code>conda env create -f environment.yml; conda env update -f environment-synthetic-data.yml</code>
     - <code>conda activate rtcloud</code>
 6. Install node module dependencies<br>
     - <code>cd web; npm install; cd ..</code>

--- a/environment-synthetic-data.yml
+++ b/environment-synthetic-data.yml
@@ -1,0 +1,8 @@
+name: rtcloud
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - brainiak::brainiak  # specifing the channel
+  - nomkl
+  - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  - awscli
   - bcrypt
   - boto3
   - dcm2niix

--- a/environment.yml
+++ b/environment.yml
@@ -2,36 +2,29 @@ name: rtcloud
 channels:
   - defaults
   - conda-forge
-  - brainiak
 dependencies:
-  - awscli
   - bcrypt
-  - brainiak
   - boto3
   - dcm2niix
   - flake8
   - indexed_gzip  # for efficient random access of gzipped files with Nibabel
-  - inflect
-  - ipython
   - jupyter
   - mypy
   - nibabel
   - nilearn
   - nodejs
   - numpy
-  - openssl
   - pip
   - pydicom
   - pytest
   - python=3.7
   - requests
   - rpyc
-  - scikit-learn
   - scipy
   - toml
   - tornado
   - websocket-client
-  - wsaccel
+  - wsaccel # for websocket acceleration
   - pip:
     - inotify
     - pybids


### PR DESCRIPTION
Installing the rtcloud conda environment is slow due to the numpy<1.20 requirement for Brainiak (>1 hour installation). But if we do the installation in two steps, first the normal rtcloud environment, and then the packages needed for synthetic data generation it completes in less than 5 minutes.

So this change splits the environment.yml into the two installation steps and updates the instructions accordingly.