### PR TITLE
fixing cert expiration; updates to rundocker script

### DIFF
--- a/scripts/make-sslcert.sh
+++ b/scripts/make-sslcert.sh
@@ -25,13 +25,11 @@ if [ -z $URL ]; then
   URL='localhost'
 fi
 
-current_date_time="`date +%Y%m%d%H%M%S`"
-START_DATE=$current_date_time"Z"
-# certificate will expire one year from now
+# certificate will expire one year from Jan 1 of current year
 # some browsers require certificates to expire after a year
-END_DATE=$(($current_date_time + 10000000000))"Z"
-echo "start date: " $START_DATE
-echo "end date: " $END_DATE
+current_year="`date +%Y`"
+START_DATE=$current_year"0101120000Z"
+END_DATE=$(($current_year + 1))"0101120000Z"
 
 if [ ! -d "certs" ]; then
   mkdir certs
@@ -114,6 +112,15 @@ openssl ca -selfsign -md sha256 -batch -outdir ./ -keyfile rtcloud_private.key \
    -config tmp/ca.config -extensions v3_req -startdate $START_DATE -enddate $END_DATE \
    -in tmp/rtcloud.csr -out rtcloud.crt
 
-echo "ssl cert id: " $(md5sum rtcloud.crt)
-echo "ssl key id: " $(md5sum rtcloud_private.key)
+# Print hashes
+# GNU uses md5sum but Macs may only have md5
+if ! command -v md5sum
+then
+  echo "ssl cert id: " $(md5 rtcloud.crt)
+  echo "ssl key id: " $(md5 rtcloud_private.key)
+else
+  echo "ssl cert id: " $(md5sum rtcloud.crt)
+  echo "ssl key id: " $(md5sum rtcloud_private.key)
+fi
+
 popd

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -3,6 +3,11 @@
 # if $PROJ_DIR is not set and --projDir is not provided, then
 # no local project directory will be mapped into the docker container
 
+# example: scripts/run-docker.sh scripts/run-projectInterface.sh -p sample -ip $IP --projDir $PROJ_DIR 
+
+# if -xl and -lite are not provided, use docker image brainiak/rtcloud:latest
+DOCKER_IMAGE="brainiak/rtcloud:latest"
+
 # get commandline args
 args=("${@}")
 for i in ${!args[@]}; do
@@ -12,8 +17,14 @@ for i in ${!args[@]}; do
       PROJ_DIR=${args[i+1]}
       unset 'args[i]'
       unset 'args[i+1]'
+    elif [[ ${args[i]} = "-xl" ]]; then
+      DOCKER_IMAGE="brainiak/rtcloudxl:latest"
+    elif [[ ${args[i]} = "-lite" ]]; then
+      DOCKER_IMAGE="brainiak/rtcloudlite:latest"
     elif [[ ${args[i]} = "-h" ]]; then
       echo "USAGE: $0 --projDir <project-dir-to-map> [list of commands to run in docker image]"
+      echo "USAGE: $0 -xl use docker image brainiak/rtcloudxl:latest"
+      echo "USAGE: $0 -lite use docker image brainiak/rtcloudlite:latest"
       exit 0
     fi
 done
@@ -24,6 +35,9 @@ if [[ ! -z $PROJ_DIR ]]; then
   MAP_PARAM="-v $PROJ_DIR:/rt-cloud/projects/$PROJ_NAME"
 fi
 
+# create ~/certs if it doesnt exist
+[[ -d ~/certs ]] || mkdir ~/certs
 
-echo "docker run -it --rm -v certs:/rt-cloud/certs $MAP_PARAM -p 8888:8888 -p 6080:6080 brainiak/rtcloud:latest" "${args[@]}"
-docker run -it --rm -v certs:/rt-cloud/certs $MAP_PARAM -p 8888:8888 -p 6080:6080 brainiak/rtcloud:latest "${args[@]}"
+echo ${args[@]}
+echo "docker run -it --rm -v ~/certs:/rt-cloud/certs $MAP_PARAM -p 8888:8888 -p 6080:6080 $DOCKER_IMAGE" "${args[@]}"
+docker run -it --rm -v ~/certs:/rt-cloud/certs $MAP_PARAM -p 8888:8888 -p 6080:6080 $DOCKER_IMAGE "${args[@]}"


### PR DESCRIPTION
Certificates now expire 1 year from Jan 1 of current year. Hashes printed using the md5 or md5sum function (whichever is available). run-docker.sh now makes/uses the home directory certs folder, not a certs volume which can present permission issues. run-docker.sh now supports -xl or -lite flags which will use the latest docker image of rtcloudxl or rtcloudlite respectively (otherwise defaults to rtcloud:latest)